### PR TITLE
[ #61] Stop process when something wrong with directory

### DIFF
--- a/main.go
+++ b/main.go
@@ -139,6 +139,7 @@ func NewEngine() *gin.Engine {
 		files, err := getFileInfoAndPath(sharedPath)
 		if err != nil {
 			c.HTML(http.StatusNotFound, "404.tmpl", gin.H{})
+			log.Fatalf("%v: %s", err, sharedPath)
 		}
 		c.HTML(http.StatusOK, "list.tmpl", gin.H{
 			"files": files,


### PR DESCRIPTION
공유 디렉토리를 지정하지 않는 경우 로그인 하면 버그 발생하는 경우 수정.

공유 디렉토리를 지정하지 않는 경우 로그인에 성공한 뒤 디렉토리 정보 받아올 때 에러가 발생한다. 이 경우 프로세스를 중단시키고 로그를 출력하기로 함.