### PR TITLE
set download file name, change path in windows and fix little bug

### DIFF
--- a/handlers/down.go
+++ b/handlers/down.go
@@ -33,7 +33,8 @@ func Down(c *gin.Context) {
 		log.Error(err)
 		c.HTML(http.StatusNotFound, "errors/404.tmpl", gin.H{})
 	}
-
+	_, fileName = filepath.Split(fileName)
+	c.Writer.Header().Set("content-disposition", "attachment; filename=" + fileName)
 	c.Data(http.StatusOK, "application/octet-stream", filedata)
 
 }
@@ -51,10 +52,6 @@ func makeZip(foldername string) (string, error) {
 	filepath.Walk(foldername, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
-		}
-
-		if info.Name() == filepath.Base(foldername) {
-			return nil
 		}
 
 		header, err := zip.FileInfoHeader(info)

--- a/handlers/set-password.go
+++ b/handlers/set-password.go
@@ -8,7 +8,7 @@ import (
 )
 
 func SetPasswordForm(c *gin.Context) {
-	c.HTML(http.StatusOK, "set_password.tmpl", gin.H{})
+	c.HTML(http.StatusOK, "authority/set_password.tmpl", gin.H{})
 }
 
 func SetPassword(c *gin.Context) {

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"html/template"
 	"os"
+	"path/filepath"
 
 	"github.com/GeertJohan/go.rice"
 	log "github.com/Sirupsen/logrus"
@@ -62,7 +63,8 @@ func templates() *template.Template {
 		if path[0] == '.' {
 			return nil
 		}
-		template.Must(all.New(path).Parse(templateBox.MustString(path)))
+		slashedPath := filepath.ToSlash(path)
+		template.Must(all.New(slashedPath).Parse(templateBox.MustString(path)))
 		return nil
 	})
 

--- a/setting/directory.go
+++ b/setting/directory.go
@@ -1,6 +1,7 @@
 package setting
 
 import (
+	"path/filepath"
 	"strings"
 	"sync"
 )
@@ -20,7 +21,7 @@ func GetDirectory() *directory {
 }
 
 func (d *directory) ValidDir(path string) bool {
-	if strings.HasPrefix(path, d.Path) {
+	if strings.HasPrefix(filepath.ToSlash(path), filepath.ToSlash(d.Path)) {
 		return true
 	}
 	return false


### PR DESCRIPTION
다운받는 파일의 이름을 지정, 윈도우에서 폴더를 \로 구분하는 것을 /로 변경, zip으로 받을 때 root랑 같은 이름의 폴더 안되는 버그 수정