### PR TITLE
Feature/new session

### DIFF
--- a/handlers/check-login.go
+++ b/handlers/check-login.go
@@ -3,21 +3,19 @@ package handlers
 import (
 	"net/http"
 
-	"github.com/gin-gonic/contrib/sessions"
 	"github.com/gin-gonic/gin"
 	"github.com/zeropage/mukgoorm/grant"
+	"github.com/zeropage/mukgoorm/session"
 )
 
-const SESSION_EXPIRE_TIME int = 1800
-
 func CheckLogin(c *gin.Context) {
-	session := sessions.Default(c)
+	sess, _ := session.GlobalSessions.SessionStart(c.Writer, c.Request)
+	defer sess.SessionRelease(c.Writer)
 
-	if auth, ok := grant.FromSession(session.Get("authority")); ok {
-		session.Options(sessions.Options{MaxAge: SESSION_EXPIRE_TIME})
+	if auth, ok := grant.FromSession(sess.Get("authority")); ok {
 		c.Set("authority", auth)
-		return
 	} else {
+		session.GlobalSessions.SessionDestroy(c.Writer, c.Request)
 		c.Redirect(http.StatusSeeOther, "/login")
 		c.Abort()
 	}

--- a/handlers/login.go
+++ b/handlers/login.go
@@ -3,9 +3,9 @@ package handlers
 import (
 	"net/http"
 
-	"github.com/gin-gonic/contrib/sessions"
 	"github.com/gin-gonic/gin"
 	"github.com/zeropage/mukgoorm/grant"
+	"github.com/zeropage/mukgoorm/session"
 )
 
 func LoginForm(c *gin.Context) {
@@ -14,13 +14,12 @@ func LoginForm(c *gin.Context) {
 
 func Login(c *gin.Context) {
 	password := c.PostForm("password")
-
 	authority := grant.FromPassword(password)
-	session := sessions.Default(c)
+
+	sess, _ := session.GlobalSessions.SessionStart(c.Writer, c.Request)
+	defer sess.SessionRelease(c.Writer)
 	// INFO: if you just put authority which is Grant type, then session save nil....
-	session.Set("authority", int(authority))
-	session.Options(sessions.Options{MaxAge: SESSION_EXPIRE_TIME})
-	session.Save()
+	sess.Set("authority", int(authority))
 
 	c.Redirect(http.StatusFound, "/")
 }

--- a/handlers/set-password.go
+++ b/handlers/set-password.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
+	"github.com/zeropage/mukgoorm/session"
 	"github.com/zeropage/mukgoorm/setting"
 )
 
@@ -16,6 +17,8 @@ func SetPassword(c *gin.Context) {
 
 	sharePassword.AdminPassword = c.PostForm("adminPassword")
 	sharePassword.ReadOnlyPassword = c.PostForm("readOnlyPassword")
+
+	session.ClearSessions()
 
 	c.Redirect(http.StatusSeeOther, "/login")
 }

--- a/session/session.go
+++ b/session/session.go
@@ -1,0 +1,40 @@
+package session
+
+import (
+	"github.com/astaxie/beego/session"
+)
+
+var GlobalSessions *session.Manager
+
+func ClearSessions() {
+	config := timeConfig(-1, -1, -1)
+	GlobalSessions, _ = session.NewManager("memory", config)
+
+	GlobalSessions.GC()
+
+	config = timeConfig(3600, 3600, 3600)
+	GlobalSessions, _ = session.NewManager("memory", config)
+}
+
+func timeConfig(gctime, maxtime int64, cookietime int) *session.ManagerConfig {
+	return &session.ManagerConfig{
+		Gclifetime:     gctime,
+		Maxlifetime:    maxtime,
+		CookieLifeTime: cookietime,
+	}
+}
+
+func init() {
+	config := &session.ManagerConfig{
+		CookieName:      "gosessionid",
+		EnableSetCookie: true,
+		Gclifetime:      3600,
+		Maxlifetime:     3600,
+		Secure:          false,
+		CookieLifeTime:  3600,
+		ProviderConfig:  "",
+	}
+
+	GlobalSessions, _ = session.NewManager("memory", config)
+	go GlobalSessions.GC()
+}

--- a/session/session_test.go
+++ b/session/session_test.go
@@ -1,0 +1,56 @@
+package session
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+)
+
+func PerformRequest(r http.Handler, method, path, cookie string) *httptest.ResponseRecorder {
+	req, _ := http.NewRequest(method, path, nil)
+	req.Header.Add("Cookie", cookie)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w
+}
+
+func TestClearSessions(t *testing.T) {
+	sessionId := ""
+	cookie := ""
+
+	r := gin.Default()
+	r.GET("/test", func(c *gin.Context) {
+		sess, _ := GlobalSessions.SessionStart(c.Writer, c.Request)
+		defer sess.SessionRelease(c.Writer)
+
+		if sessionId == "" {
+			sessionId = sess.SessionID()
+		} else {
+			assert.NotEqual(t, sessionId, sess.SessionID())
+		}
+		sess.Set("key", "value")
+	})
+
+	res := PerformRequest(r, "GET", "/test", cookie)
+	cookie = res.Header().Get("Set-Cookie")
+
+	r.DELETE("/flush", func(c *gin.Context) {
+		assert.Equal(t, 1, GlobalSessions.GetActiveSession())
+
+		ClearSessions()
+		assert.Equal(t, 0, GlobalSessions.GetActiveSession())
+
+		sess, _ := GlobalSessions.SessionStart(c.Writer, c.Request)
+		defer sess.SessionRelease(c.Writer)
+		assert.Equal(t, 1, GlobalSessions.GetActiveSession())
+		assert.NotEqual(t, sess.Get("key"), "value")
+	})
+
+	res = PerformRequest(r, "DELETE", "/flush", cookie)
+	cookie = res.Header().Get("Set-Cookie")
+
+	res = PerformRequest(r, "GET", "/test", cookie)
+}


### PR DESCRIPTION
기존의 gorilla/session은 전체 세션들을 핸들링 할 수 있는 방법이 없어서 새로운 라이브러리(https://beego.me/docs/module/session.md) 로 교체함. 

reflect로 unexported filed인 세션 프로바이더에 접근하려고 했으나  다음 이슈(https://github.com/golang/go/issues/15673)와 같은 go 언어의 정책으로 reflect를 이용해서 unexported feiled에 접근할 수 없음. 

다른 해결방법(http://www.alangpierce.com/blog/2016/03/17/adventures-in-go-accessing-unexported-functions/)이 존재하나 라이브버리를 교체하는 것이 낫다고 판단함. 